### PR TITLE
Add conda build recipe and anaconda.org build script

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,21 @@
+package: rft1d
+
+platform: 
+ - linux-64
+
+engine:
+ #- python=3.4
+ #- python=3.5
+ - python=2.7
+
+script:
+  - conda build recipe
+
+after_success:
+   - conda convert -p all /opt/miniconda/conda-bld/linux-64/rft1d*.tar.bz2 -o /opt/miniconda/conda-bld
+
+after_failure:
+   - echo "Build failed!"
+
+build_targets:
+   - /opt/miniconda/conda-bld/*/*.tar.bz2

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: rft1d
+  version: {{ environ['GIT_DESCRIBE_TAG'] }}
+
+source:
+   path: ../
+
+
+build:
+  script: python setup.py install
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+
+    
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - scipy >=0.15
+    - numpy >=1.9
+
+
+test:
+  imports:
+    - rft1d
+
+
+
+about:
+  home: http://www.spm1d.org/rft1d/
+  license: GPL


### PR DESCRIPTION
This adds a conda build recipe. Conda packages makes it very easy to install the packages in python a distributions that have conda. 

 It also adds a build-script to build packages on Anaconda.org. This makes it a 'one-click' procedure to build conda packages for all platforms.
